### PR TITLE
Process qualities with HTML in name

### DIFF
--- a/background.js
+++ b/background.js
@@ -60,7 +60,7 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
             })
             .catch(error => {
                 console.error(error);
-                console.debug("[FL 1-Click Wiki] Error has occured, falling back to using title.")
+                console.debug("[FL 1-Click Wiki] Error has occurred, falling back to using title.")
                 openNewTab(destination, targetPosition);
             });
     } else {

--- a/inject.js
+++ b/inject.js
@@ -242,7 +242,7 @@
                         if (associatedQuality != null) {
                             window.postMessage({
                                 action: "openInFLWiki",
-                                title: associatedQuality.qualityName,
+                                title: associatedQuality.qualityName.replace(/(<([^>]+)>)/gi, ""),
                                 entityId: associatedQuality.qualityId,
                                 filterCategories: ["Quality", "Item", "World Quality"],
                             })


### PR DESCRIPTION
A Quality name can contain HTML, most prominently `<i>` italic text. For example, in [_Khatun_-class Electric Launch](https://fallenlondon.wiki/wiki/Khatun-class_Electric_Launch), the Khatun is italic. The addon would pass that as is to the wiki, leading to an error.

The fix strips HTML tags from the quality name.