### PR TITLE
Fix storylet ID not being recorded when using an item.

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -359,7 +359,7 @@
                 if (data.phase === "Available" || data.phase === "End") {
                     // We are not in any storylet at the moment, or it just ended
                     currentStoryletId = null;
-                } else if (data.phase === "In") {
+                } else if (["In", "InItemUse"].includes(data.phase)) {
                     // Store retrieved ID to speed up Wiki page lookup in the future
                     currentStoryletId = data.storylet.id;
                 }


### PR DESCRIPTION
1-Click Wiki tries to keep track of the current storylet ID to narrow the list of possible Wiki pages as much as possible. Unfortunately, due to an oversight, this value was not correctly recorded when the storylet opens up after clicking an item.
While this will not prevent reaching a correct page due to built-in "search-by-name" fallbacks, this still can be improved to reach an actual 1-Click™ experience.